### PR TITLE
Add sourcemap support in stack traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ The code below shows a sample configuration of the preprocessor.
 // karma.conf.js
 module.exports = function(config) {
   config.set({
-    preprocessors: {
-      '**/*.js': ['sourcemap']
-    }
+    frameworks: ['sourcemap']
   });
 };
 ```

--- a/index.js
+++ b/index.js
@@ -1,8 +1,21 @@
 var fs = require('fs');
 var path = require('path');
 
-var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
-  var log = logger.create('preprocessor.sourcemap');
+var createPattern = function(path) {
+  return {pattern: path, included: true, served: true, watched: false};
+};
+
+var setupStackTraceSupport = function(files) {
+  var sourceMapSupportPath = path.dirname(require.resolve('source-map-support')) + '/browser-source-map-support.js';
+
+  // This is the reverse order of how this is loaded on the page.
+  files.unshift(createPattern(__dirname + '/lib/init.js'));
+  files.unshift(createPattern(sourceMapSupportPath));
+};
+
+var createSourceMapLocatorPreprocessor = function(args, logger, helper, files) {
+  var log = logger.create('framework.sourcemap');
+  setupStackTraceSupport(files);
 
   return function(content, file, done) {
     function sourceMapData(data){
@@ -53,9 +66,9 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
   };
 };
 
-createSourceMapLocatorPreprocessor.$inject = ['args', 'logger', 'helper'];
+createSourceMapLocatorPreprocessor.$inject = ['args', 'logger', 'helper', 'config.files'];
 
 // PUBLISH DI MODULE
 module.exports = {
-  'preprocessor:sourcemap': ['factory', createSourceMapLocatorPreprocessor]
+  'framework:sourcemap': ['factory', createSourceMapLocatorPreprocessor]
 };

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,0 +1,1 @@
+sourceMapSupport.install();

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "name": "Gabriele Genta",
     "email": "gabriele.genta@gmail.com"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "source-map-support": "^0.2.8"
+  }
 }


### PR DESCRIPTION
This will modify the stack trace behavior to point to the source of a
files error. Originally this plugin only allows you to debug tests with
the sourcemaps.

Fixes #3