### PR TITLE
Ignore empty lines after inline source map

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,12 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
       });
     }
 
-    var lastLine = content.split(new RegExp(require('os').EOL)).pop();
+    var lines = content.split(new RegExp(require('os').EOL));
+    var lastLine = lines.pop();
+    while (new RegExp("^\\s*$").test(lastLine)) {
+      lastLine = lines.pop();
+    }
+
     var match = lastLine.match(/^\/\/#\s*sourceMappingURL=(.+)$/);
     var mapUrl = match && match[1];
     if (!mapUrl) {


### PR DESCRIPTION
Hi, on Mac OS X, when using your plugin on the output of grunt-browserify, it fails because the last line it finds is the Unix-y blank line.  This trailing blank line doesn't match the RegEx for sourceMappingURL, of course, and so lines numbers are not mapped to their true source.  This PR ignores any lines at the end of the file that contain only whitespace.  Thanks!