### PR TITLE
Change multi-line split regex to work cross-platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
       });
     }
 
-    var lines = content.split(new RegExp(require('os').EOL));
+    var lines = content.split(/\n/);
     var lastLine = lines.pop();
     while (new RegExp("^\\s*$").test(lastLine)) {
       lastLine = lines.pop();


### PR DESCRIPTION
When working with Webpack `require('os').EOL` does not adequately split
on line breaks.

Fixes #12