### PR TITLE
Prevent from RangeError exceptions on large data

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
 
     function inlineMap(inlineData){
       var data;
-      var b64Match = inlineData.match(/^data:.+\/(.+);base64,(.*)$/);
+      var b64Match = inlineData.match(/^data:..*\/(..*);base64,(.*)$/);
       if (b64Match !== null && b64Match.length == 3) {
         // base64-encoded JSON string
         log.debug('base64-encoded source map for', file.originalPath);


### PR DESCRIPTION
On io.js 2.2.1 and 2.3.1 (by the time of writing it's the latest) I have this error:

```
RangeError: Maximum call stack size exceeded
  at String.match (native)
```

It happens only on the second pass while karma is working (auto watching and reruns the specs).

For more details read this issue:

https://github.com/nodejs/io.js/issues/759

Similar issues:

https://github.com/thlorenz/convert-source-map/pull/10
https://github.com/thlorenz/convert-source-map/pull/11

Looks like this related to optimizations in V8 regex engine:
http://blog.chromium.org/2009/02/irregexp-google-chromes-new-regexp.html

Simply changing from `.+` to `..*` equivalent rule fixes an issue with match function.