### PR TITLE
Drop usage of regexp.exec and string.match

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 var fs = require('fs');
 var path = require('path');
 
-var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
+var sourcemapUrlRegeExp = /^\/\/#\s*sourceMappingURL=/;
+
+var createSourceMapLocatorPreprocessor = function(args, logger) {
   var log = logger.create('preprocessor.sourcemap');
 
   return function(content, file, done) {
@@ -40,12 +42,16 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
 
     var lines = content.split(/\n/);
     var lastLine = lines.pop();
-    while (new RegExp("^\\s*$").test(lastLine)) {
+    while (/^\s*$/.test(lastLine)) {
       lastLine = lines.pop();
     }
 
-    var match = /^\/\/#\s*sourceMappingURL=(.+)$/.exec(lastLine);
-    var mapUrl = match && match[1];
+    var mapUrl;
+
+    if (sourcemapUrlRegeExp.test(lastLine)) {
+      mapUrl = lastLine.replace(sourcemapUrlRegeExp, '');
+    }
+
     if (!mapUrl) {
       fileMap(file.path + ".map");
     } else if (/^data:application\/json/.test(mapUrl)) {
@@ -56,7 +62,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
   };
 };
 
-createSourceMapLocatorPreprocessor.$inject = ['args', 'logger', 'helper'];
+createSourceMapLocatorPreprocessor.$inject = ['args', 'logger'];
 
 // PUBLISH DI MODULE
 module.exports = {


### PR DESCRIPTION
This tries to fix @elliottsj's problem in https://github.com/demerzel3/karma-sourcemap-loader/pull/18#issuecomment-146689191

I'm not able to test it, but I verified it did NOT break base-64 encoded inline sourcemaps.

Should be tested before merge though, with external sourcemaps.

Test by doing `npm install --save-dev simenb/karma-sourcemap-loader#remove-match`