### PR TITLE
Use files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.6",
   "description": "Karma plugin that locates and loads existing javascript source map files.",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:demerzel3/karma-sourcemap-loader.git"


### PR DESCRIPTION
I noticed idea-folder was included in the package, as well as extraneous `.npmignore`.

![image](https://cloud.githubusercontent.com/assets/1404810/10410601/c0cae90c-6f46-11e5-94ad-b3ed56d66bc9.png)

This small change makes the package this instead:
```
    2466 karma-sourcemap-loader-0.3.6.tgz
-rw-r--r--  0 501    20        529 Oct 10 12:00 package/package.json
-rw-r--r--  0 501    20       1378 Oct 10 11:39 package/README.md
-rw-r--r--  0 501    20       1102 Oct 10 11:35 package/LICENSE
-rw-r--r--  0 501    20       1920 Oct 10 12:00 package/index.js
```