### PR TITLE
fix charset prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
     }
 
     function inlineMap(inlineData){
-      if (/^;base64,/.test(inlineData)) {
+      if (/;base64,/.test(inlineData)) {
         // base64-encoded JSON string
         log.debug('base64-encoded source map for', file.originalPath);
-        var buffer = new Buffer(inlineData.slice(';base64,'.length), 'base64');
+        var buffer = new Buffer(inlineData.split(';base64,')[1], 'base64');
         sourceMapData(buffer.toString());
       } else {
         // straight-up URL-encoded JSON string


### PR DESCRIPTION
Hi, so the sourcemaps generated by the browserify tsify plugin start with:

    //# sourceMappingURL=data:application/json;charset=utf-8;base64,

The additional charset information caused this plugin to crash. I fixed it for my use-case, though there probably is a better way of doing this.

Feel free to refactor or merge in :)