### PR TITLE
Use graceful-fs to avoid `EMFILE: too many open files` errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 var createSourceMapLocatorPreprocessor = function(args, logger, helper) {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "name": "Gabriele Genta",
     "email": "gabriele.genta@gmail.com"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "graceful-fs": "^4.1.2"
+  }
 }


### PR DESCRIPTION
In some cases like this one https://github.com/angular/angular/issues/5471, using karma-sourcemap-loader may lead to file access errors.
Switching from fs to https://github.com/isaacs/node-graceful-fs solves the issue.