### PR TITLE
Fix the bug by having charset info in inline source maps.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,10 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
     function inlineMap(inlineData){
 
       var charset = 'utf-8';
-      if (/^;charset=([^;]+);/.test(inlineData)) {
-        var matches = inlineData.match(/^;charset=([^;]+);/)
+      var charsetRegex = /^;charset=([^;]+);/;
+
+      if (charsetRegex.test(inlineData)) {
+        var matches = inlineData.match(charsetRegex);
 
         if (matches.length === 2) {
           charset = matches[1];

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var path = require('path');
 
 var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
   var log = logger.create('preprocessor.sourcemap');
+  var charsetRegex = /^;charset=([^;]+);/;
 
   return function(content, file, done) {
     function sourceMapData(data){
@@ -13,8 +14,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
     function inlineMap(inlineData){
 
       var charset = 'utf-8';
-      var charsetRegex = /^;charset=([^;]+);/;
-
+      
       if (charsetRegex.test(inlineData)) {
         var matches = inlineData.match(charsetRegex);
 

--- a/index.js
+++ b/index.js
@@ -11,11 +11,22 @@ var createSourceMapLocatorPreprocessor = function(args, logger, helper) {
     }
 
     function inlineMap(inlineData){
+
+      var charset = 'utf-8';
+      if (/^;charset=([^;]+);/.test(inlineData)) {
+        var matches = inlineData.match(/^;charset=([^;]+);/)
+
+        if (matches.length === 2) {
+          charset = matches[1];
+          inlineData = inlineData.slice(matches[0].length -1);
+        }
+      }
+
       if (/^;base64,/.test(inlineData)) {
         // base64-encoded JSON string
         log.debug('base64-encoded source map for', file.originalPath);
         var buffer = new Buffer(inlineData.slice(';base64,'.length), 'base64');
-        sourceMapData(buffer.toString());
+        sourceMapData(buffer.toString(charset));
       } else {
         // straight-up URL-encoded JSON string
         log.debug('raw inline source map for', file.originalPath);


### PR DESCRIPTION
Fix the bug by having charset info in inline source maps.
Use the charset to decode the base64 string


Fix for #27 

