### PR TITLE
Optionally convert webpack URIs to local filesystem paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,16 @@ module.exports = function(config) {
   config.set({
     preprocessors: {
       '**/*.js': ['sourcemap']
+    },
+    sourcemap: {
+      useLocalPaths: false
     }
   });
 };
 ```
+
+### Configuration Parameters
+
+* useLocalPaths - bool - converts webpack sourcemap paths to the local path of the 
+original source.  This is useful when running tests from the commandline so that the
+original source can be reached simply by clicking the path in your terminal.

--- a/index.js
+++ b/index.js
@@ -3,13 +3,24 @@ var path = require('path');
 
 var sourcemapUrlRegeExp = /^\/\/#\s*sourceMappingURL=/;
 
-var createSourceMapLocatorPreprocessor = function(args, logger) {
+var createSourceMapLocatorPreprocessor = function(args, logger, config) {
   var log = logger.create('preprocessor.sourcemap');
   var charsetRegex = /^;charset=([^;]+);/;
 
   return function(content, file, done) {
+    function resolveLocalPath(path) {
+      return path
+          .replace(/webpack:\/\//, process.cwd())
+          .replace(/\?[^:]*/, '');
+    }
+
     function sourceMapData(data){
       file.sourceMap = JSON.parse(data);
+      if (config && config.useLocalPaths) {
+          file.sourceMap.sources = file.sourceMap.sources.map(function (path) {
+              return resolveLocalPath(path);
+          });
+      }
       done(content);
     }
 
@@ -75,7 +86,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger) {
   };
 };
 
-createSourceMapLocatorPreprocessor.$inject = ['args', 'logger'];
+createSourceMapLocatorPreprocessor.$inject = ['args', 'logger', 'config.sourcemap'];
 
 // PUBLISH DI MODULE
 module.exports = {


### PR DESCRIPTION
When running tests, it can be nice to have sourcemaps point to the local filesystem path of the original file.  It makes it easier to open the source file in your text editor.

This change introduces a configuration for karma-sourcemap-loader with a `useLocalPaths` parameter that enables the conversion of webpack URIs to local paths.
