### PR TITLE
Configurable transformation of sourcemap after loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Why
 
+This is a fork to provide the 'useSourceRoot' option and make it available via npm.
+
 When you use karma not in isolation but as part of a build process (e.g. using grunt
 or gulp) it is often the case that the compilation/transpilation is done on a previous
 step of the process and not handled by karma preprocessors. In these cases source maps

--- a/README.md
+++ b/README.md
@@ -45,7 +45,14 @@ module.exports = function(config) {
   config.set({
     preprocessors: {
       '**/*.js': ['sourcemap']
+    },
+    sourcemap: {
+      useSourceRoot: '/'
     }
   });
 };
 ```
+
+### Configuration Parameters
+
+* useSourceRoot - string - overrides the sourceRoot in the source map with a custom value.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# karma-sourcemap-loader
+# karma-sourcemap-loader-srcroot
 
 > Preprocessor that locates and loads existing source maps.
 
@@ -22,18 +22,18 @@ Hello.js.map.
 
 ## Installation
 
-Just add `karma-sourcemap-loader` as a devDependency in your `package.json`.
+Just add `karma-sourcemap-loader-srcroot` as a devDependency in your `package.json`.
 ```json
 {
   "devDependencies": {
-    "karma-sourcemap-loader": "~0.3"
+    "karma-sourcemap-loader-srcroot": "~0.3"
   }
 }
 ```
 
 Or issue the following command:
 ```bash
-npm install karma-sourcemap-loader --save-dev
+npm install karma-sourcemap-loader-srcroot --save-dev
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Why
 
-This is a fork to provide the 'useSourceRoot' option and make it available via npm.
+This is a fork to provide the 'transform' option and make it available via npm.
 
 When you use karma not in isolation but as part of a build process (e.g. using grunt
 or gulp) it is often the case that the compilation/transpilation is done on a previous
@@ -49,7 +49,9 @@ module.exports = function(config) {
       '**/*.js': ['sourcemap']
     },
     sourcemap: {
-      useSourceRoot: '/'
+      transform: function(mapData) {
+        mapData.sourceRoot = '/';
+      }
     }
   });
 };
@@ -57,4 +59,4 @@ module.exports = function(config) {
 
 ### Configuration Parameters
 
-* useSourceRoot - string - overrides the sourceRoot in the source map with a custom value.
+* transform - function - allows transforming the map data prior to loading.

--- a/index.js
+++ b/index.js
@@ -3,13 +3,17 @@ var path = require('path');
 
 var sourcemapUrlRegeExp = /^\/\/#\s*sourceMappingURL=/;
 
-var createSourceMapLocatorPreprocessor = function(args, logger) {
+var createSourceMapLocatorPreprocessor = function(args, logger, config) {
   var log = logger.create('preprocessor.sourcemap');
   var charsetRegex = /^;charset=([^;]+);/;
 
   return function(content, file, done) {
     function sourceMapData(data){
-      file.sourceMap = JSON.parse(data);
+      var mapData = JSON.parse(data);
+      if (config && config.useSourceRoot) {
+          mapData.sourceRoot = config.useSourceRoot;
+      }
+      file.sourceMap = mapData;
       done(content);
     }
 
@@ -75,9 +79,10 @@ var createSourceMapLocatorPreprocessor = function(args, logger) {
   };
 };
 
-createSourceMapLocatorPreprocessor.$inject = ['args', 'logger'];
+createSourceMapLocatorPreprocessor.$inject = ['args', 'logger', 'config.sourcemap'];
 
 // PUBLISH DI MODULE
 module.exports = {
   'preprocessor:sourcemap': ['factory', createSourceMapLocatorPreprocessor]
 };
+

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
   return function(content, file, done) {
     function sourceMapData(data){
       var mapData = JSON.parse(data);
-      if (config && config.useSourceRoot) {
-          mapData.sourceRoot = config.useSourceRoot;
+      if (config && config.transform) {
+          config.transform(mapData);
       }
       file.sourceMap = mapData;
       done(content);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-sourcemap-loader-srcroot",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Karma plugin that locates and loads existing javascript source map files.",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "karma-sourcemap-loader",
-  "version": "0.3.7",
+  "name": "karma-sourcemap-loader-srcroot",
+  "version": "0.3.8",
   "description": "Karma plugin that locates and loads existing javascript source map files.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Sourcemap paths don't always reflect the location they are eventually run from. This is particularly evident when using webstorm which forces a 'project/' sub directory in the url, making it difficult to use the same set of source maps for both browser development and unit tests.

This option allows remapping the sourceRoot as it is loaded.