### PR TITLE
Allow remapping source paths, fix raw source map handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 
 npm-debug.log
 node_modules
+test/out
+coverage

--- a/README.md
+++ b/README.md
@@ -96,3 +96,20 @@ module.exports = function(config) {
   });
 };
 ```
+
+The code below shows a sample configuration of the preprocessor with a strict error checking. A missing or an invalid source map will cause the test run fail.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    plugins: ['karma-sourcemap-loader'],
+    preprocessors: {
+      '**/*.js': ['sourcemap']
+    },
+    sourceMapLoader: {
+      strict: true
+    }
+  });
+};
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 When you use karma not in isolation but as part of a build process (e.g. using grunt
 or gulp) it is often the case that the compilation/transpilation is done on a previous
 step of the process and not handled by karma preprocessors. In these cases source maps
-don't get loaded by karma and you lose the advantages of having them.
+don't get loaded by karma and you lose the advantages of having them. Collecting
+the test code coverage using an instrumented code with source maps, for example.
+
+Another reason may be the need for modifying relative source paths in source maps
+to make sure that they point to source files in the project running the tests.
 
 ## How it works
 
@@ -39,12 +43,55 @@ npm install karma-sourcemap-loader --save-dev
 ## Configuration
 
 The code below shows a sample configuration of the preprocessor.
+
 ```js
 // karma.conf.js
 module.exports = function(config) {
   config.set({
+    plugins: ['karma-sourcemap-loader'],
     preprocessors: {
       '**/*.js': ['sourcemap']
+    }
+  });
+};
+```
+
+The code below shows a configuration of the preprocessor with remapping of source file paths in source maps using path prefixes. The object `remapPrefixes` contains path prefixes as keys, which if they are detected in a source path, will be replaced by the key value. After the first detected prefix gets replaced, other prefixes will be ignored..
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    plugins: ['karma-sourcemap-loader'],
+    preprocessors: {
+      '**/*.js': ['sourcemap']
+    },
+    sourceMapLoader: {
+      remapPrefixes: {
+        '/myproject/': '../src/',
+        '/otherdep/': '../node_modules/otherdep/'
+      }
+    }
+  });
+};
+```
+
+The code below shows a configuration of the preprocessor with remapping of source file paths in source maps using a callback. The function `remapSource` receives an original source path and may return a changed source path. If it returns `undefined` or other false-y result, the source path will not be changed.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    plugins: ['karma-sourcemap-loader'],
+    preprocessors: {
+      '**/*.js': ['sourcemap']
+    },
+    sourceMapLoader: {
+      remapSource(source) {
+        if (source.startsWith('/myproject/')) {
+          return '../src/' + source.substring(11);
+        }
+      }
     }
   });
 };

--- a/README.md
+++ b/README.md
@@ -133,6 +133,23 @@ module.exports = function(config) {
 };
 ```
 
+The code below shows a sample configuration of the preprocessor with source map loading only for files with the `sourceMappingURL` set. The default behaviour is trying to load source maps for all JavaScript files, also those without the `sourceMappingURL` set.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    plugins: ['karma-sourcemap-loader'],
+    preprocessors: {
+      '**/*.js': ['sourcemap']
+    },
+    sourceMapLoader: {
+      onlyWithURL: true
+    }
+  });
+};
+```
+
 The code below shows a sample configuration of the preprocessor with a strict error checking. A missing or an invalid source map will cause the test run fail.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -97,6 +97,42 @@ module.exports = function(config) {
 };
 ```
 
+The code below shows a sample configuration of the preprocessor with changing the `sourceRoot` property to a custom value, which will change the location where the debugger should locate the source files.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    plugins: ['karma-sourcemap-loader'],
+    preprocessors: {
+      '**/*.js': ['sourcemap']
+    },
+    sourceMapLoader: {
+      useSourceRoot: '/sources'
+    }
+  });
+};
+```
+
+The code below shows a sample configuration of the preprocessor with changing the `sourceRoot` property using a custom function to be able to compute the value depending on the path to the bundle. The `file` argument is the Karma file object `{ path, originalPath }` for the bundle.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    plugins: ['karma-sourcemap-loader'],
+    preprocessors: {
+      '**/*.js': ['sourcemap']
+    },
+    sourceMapLoader: {
+      useSourceRoot(file) {
+        return '/sources';
+      }
+    }
+  });
+};
+```
+
 The code below shows a sample configuration of the preprocessor with a strict error checking. A missing or an invalid source map will cause the test run fail.
 
 ```js

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
   var remapPrefixes = options.remapPrefixes;
   var remapSource = options.remapSource;
   var useSourceRoot = options.useSourceRoot;
+  var onlyWithURL = options.onlyWithURL;
   var strict = options.strict;
   var needsUpdate = remapPrefixes || remapSource || useSourceRoot;
 
@@ -228,7 +229,11 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
     }
 
     if (!mapUrl) {
-      fileMap(file.path + ".map", true);
+      if (onlyWithURL) {
+        done(content);
+      } else {
+        fileMap(file.path + ".map", true);
+      }
     } else if (/^data:application\/json/.test(mapUrl)) {
       inlineMap(mapUrl.slice('data:application/json'.length));
     } else {

--- a/index.js
+++ b/index.js
@@ -112,9 +112,18 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
       }
     }
 
-    function fileMap(mapPath){
+    function fileMap(mapPath, optional) {
       fs.exists(mapPath, function(exists) {
         if (!exists) {
+          if (!optional) {
+            /* c8 ignore next 3 */
+            if (strict) {
+              done(new Error('missing external source map for ' + file.originalPath));
+              return;
+            } else {
+              log.warn('missing external source map for', file.originalPath);
+            }
+          }
           done(content);
           return;
         }
@@ -168,11 +177,11 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
     }
 
     if (!mapUrl) {
-      fileMap(file.path + ".map");
+      fileMap(file.path + ".map", true);
     } else if (/^data:application\/json/.test(mapUrl)) {
       inlineMap(mapUrl.slice('data:application/json'.length));
     } else {
-      fileMap(path.resolve(path.dirname(file.path), mapUrl));
+      fileMap(path.resolve(path.dirname(file.path), mapUrl), false);
     }
   };
 };

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger) {
         log.debug('base64-encoded source map for', file.originalPath);
         var buffer = Buffer.from(inlineData.slice(';base64,'.length), 'base64');
         sourceMapData(buffer.toString(charset));
+      /* c8 ignore next 5 */
       } else {
         // straight-up URL-encoded JSON string
         log.debug('raw inline source map for', file.originalPath);
@@ -45,6 +46,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger) {
           return;
         }
         fs.readFile(mapPath, function(err, data) {
+          /* c8 ignore next */
           if (err){ throw err; }
 
           log.debug('external source map exists for', file.originalPath);

--- a/index.js
+++ b/index.js
@@ -104,11 +104,18 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
         log.debug('base64-encoded source map for', file.originalPath);
         var buffer = Buffer.from(inlineData.slice(';base64,'.length), 'base64');
         sourceMapData(buffer.toString(charset));
-      /* c8 ignore next 5 */
-      } else {
+      } else if (inlineData.startsWith(',')) {
         // straight-up URL-encoded JSON string
         log.debug('raw inline source map for', file.originalPath);
-        sourceMapData(decodeURIComponent(inlineData));
+        sourceMapData(decodeURIComponent(inlineData.slice(1)));
+      } else {
+        /* c8 ignore next 2 */
+        if (strict) {
+          done(new Error('invalid source map in ' + file.originalPath));
+        } else {
+          log.warn('invalid source map in', file.originalPath);
+          done(content)
+        }
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -138,6 +138,23 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
       });
     }
 
+    // Remap source paths in a directly served source map
+    function convertMap() {
+      var sourceMap;
+      log.debug('processing source map', file.originalPath);
+      // Preform the remapping only if there is a configuration for it
+      if (remapPrefixes || remapSource) {
+        sourceMap = JSON.parse(content);
+        remapSources(sourceMap.sources);
+        content = JSON.stringify(sourceMap);
+      }
+      done(content);
+    }
+
+    if (file.path.endsWith('.map')) {
+      return convertMap();
+    }
+
     var lines = content.split(/\n/);
     var lastLine = lines.pop();
     while (/^\s*$/.test(lastLine)) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
   var options = config && config.sourceMapLoader || {};
   var remapPrefixes = options.remapPrefixes;
   var remapSource = options.remapSource;
+  var strict = options.strict;
 
   var log = logger.create('preprocessor.sourcemap');
   var charsetRegex = /^;charset=([^;]+);/;
@@ -117,9 +118,19 @@ var createSourceMapLocatorPreprocessor = function(args, logger, config) {
           done(content);
           return;
         }
+
         fs.readFile(mapPath, function(err, data) {
-          /* c8 ignore next */
-          if (err){ throw err; }
+          /* c8 ignore next 10 */
+          if (err) {
+            if (strict) {
+              done(new Error('reading external source map failed for ' + file.originalPath + '\n' + err));
+            } else {
+              log.warn('reading external source map failed for', file.originalPath);
+              log.warn(err);
+              done(content);
+            }
+            return;
+          }
 
           log.debug('external source map exists for', file.originalPath);
           sourceMapData(data);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "scripts": {
     "pretest": "cd test && rollup -c",
-    "test": "c8 karma start test/karma.prefixes.js && c8 --no-clean karma start test/karma.handler.js && c8 report -r text -r lcov && c8 check-coverage --100"
+    "test": "c8 karma start test/karma.prefixes.js && c8 --no-clean karma start test/karma.handler.js && c8 --no-clean karma start test/karma.source-root-value.js && c8 --no-clean karma start test/karma.source-root-function.js && c8 report -r text -r lcov && c8 check-coverage --100"
   },
   "c8": {
     "reporter": []

--- a/package.json
+++ b/package.json
@@ -21,7 +21,24 @@
     "email": "gabriele.genta@gmail.com"
   },
   "license": "MIT",
+  "scripts": {
+    "pretest": "cd test && rollup -c",
+    "test": "c8 karma start test/karma.prefixes.js && c8 --no-clean karma start test/karma.handler.js && c8 report -r text -r lcov && c8 check-coverage --100"
+  },
+  "c8": {
+    "reporter": []
+  },
   "dependencies": {
     "graceful-fs": "^4.1.2"
+  },
+  "devDependencies": {
+    "c8": "^7.12.0",
+    "jasmine-core": "^4.5.0",
+    "karma": "^6.4.1",
+    "karma-brief-reporter": "^0.2.2",
+    "karma-chrome-launcher": "^3.1.1",
+    "karma-jasmine": "^5.1.0",
+    "rollup": "^3.10.1",
+    "rollup-sourcemap-path-transform": "^1.0.3"
   }
 }

--- a/test/karma.handler.js
+++ b/test/karma.handler.js
@@ -1,0 +1,13 @@
+const sharedConfig = require('./karma.shared');
+
+module.exports = function(config) {
+  config.set(Object.assign({}, sharedConfig(config), {
+    sourceMapLoader: {
+      remapSource(source) {
+        if (source.startsWith('/test/')) {
+          return `../src/${source.substring(6)}`;
+        }
+      }
+    }
+  }));
+};

--- a/test/karma.handler.js
+++ b/test/karma.handler.js
@@ -1,7 +1,7 @@
 const sharedConfig = require('./karma.shared');
 
-module.exports = function(config) {
-  config.set(Object.assign({}, sharedConfig(config), {
+module.exports = function (config) {
+  config.set(Object.assign({}, sharedConfig(config, 'test-sources'), {
     sourceMapLoader: {
       remapSource(source) {
         if (source.startsWith('/test/')) {

--- a/test/karma.prefixes.js
+++ b/test/karma.prefixes.js
@@ -1,0 +1,9 @@
+const sharedConfig = require('./karma.shared');
+
+module.exports = function(config) {
+  config.set(Object.assign({}, sharedConfig(config), {
+    sourceMapLoader: {
+      remapPrefixes: { '/test/': '../src/' }
+    }
+  }));
+};

--- a/test/karma.shared.js
+++ b/test/karma.shared.js
@@ -1,4 +1,4 @@
-module.exports = function(config) {
+module.exports = function (config, testName) {
   return {
     plugins: [
       'karma-jasmine', 'karma-brief-reporter', 'karma-chrome-launcher',
@@ -8,7 +8,7 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
 
     files: [
-      { pattern: 'test.js', nocache: true },
+      { pattern: `${testName}.js`, nocache: true },
       { pattern: 'out/*.js' },
       // The type `html` is a workaround for JavaScript parsing errors;
       // the default type is `js` and there is no type for JSON files

--- a/test/karma.shared.js
+++ b/test/karma.shared.js
@@ -9,11 +9,15 @@ module.exports = function(config) {
 
     files: [
       { pattern: 'test.js', nocache: true },
-      { pattern: 'out/*.js' }
+      { pattern: 'out/*.js' },
+      // The type `html` is a workaround for JavaScript parsing errors;
+      // the default type is `js` and there is no type for JSON files
+      { pattern: 'out/*.map', type: 'html' }
     ],
 
     preprocessors: {
-      'out/*.js': ['sourcemap']
+      'out/*.js': ['sourcemap'],
+      'out/*.map': ['sourcemap']
     },
 
     reporters: ['brief'],

--- a/test/karma.shared.js
+++ b/test/karma.shared.js
@@ -1,0 +1,29 @@
+module.exports = function(config) {
+  return {
+    plugins: [
+      'karma-jasmine', 'karma-brief-reporter', 'karma-chrome-launcher',
+      require('..')
+    ],
+
+    frameworks: ['jasmine'],
+
+    files: [
+      { pattern: 'test.js', nocache: true },
+      { pattern: 'out/*.js' }
+    ],
+
+    preprocessors: {
+      'out/*.js': ['sourcemap']
+    },
+
+    reporters: ['brief'],
+
+    browsers: ['ChromeHeadless'],
+
+    briefReporter: { renderOnRunCompleteOnly: !!process.env.CI },
+
+    // logLevel: config.LOG_DEBUG,
+    autoWatch: false,
+    singleRun: true
+  };
+};

--- a/test/karma.source-root-function.js
+++ b/test/karma.source-root-function.js
@@ -1,0 +1,11 @@
+const sharedConfig = require('./karma.shared');
+
+module.exports = function (config) {
+  config.set(Object.assign({}, sharedConfig(config, 'test-source-root'), {
+    sourceMapLoader: {
+      useSourceRoot(file) {
+        return '/sources';
+      }
+    }
+  }));
+};

--- a/test/karma.source-root-value.js
+++ b/test/karma.source-root-value.js
@@ -3,7 +3,8 @@ const sharedConfig = require('./karma.shared');
 module.exports = function (config) {
   config.set(Object.assign({}, sharedConfig(config, 'test-source-root'), {
     sourceMapLoader: {
-      useSourceRoot: '/sources'
+      useSourceRoot: '/sources',
+      onlyWithURL: true // Just to complete the code coverage
     }
   }));
 };

--- a/test/karma.source-root-value.js
+++ b/test/karma.source-root-value.js
@@ -1,9 +1,9 @@
 const sharedConfig = require('./karma.shared');
 
 module.exports = function (config) {
-  config.set(Object.assign({}, sharedConfig(config, 'test-sources'), {
+  config.set(Object.assign({}, sharedConfig(config, 'test-source-root'), {
     sourceMapLoader: {
-      remapPrefixes: { '/test/': '../src/' }
+      useSourceRoot: '/sources'
     }
   }));
 };

--- a/test/rollup.config.js
+++ b/test/rollup.config.js
@@ -1,0 +1,41 @@
+const { readFile, writeFile } = require('fs/promises');
+const { createPathTransform } = require('rollup-sourcemap-path-transform');
+
+// Replace ../src/ with /test/ in source map sources
+const sourcemapPathTransform = createPathTransform({
+  prefixes: { '*src/': '/test/' },
+  requirePrefix: true,
+});
+
+module.exports = [
+  {
+    input: 'src/source.js',
+    output: {
+      file: 'out/bundle.js',
+      format: 'iife', // Karma cannot load ES modules
+      sourcemap: true,
+      sourcemapPathTransform,
+      plugins: [{
+        async writeBundle() {
+          const bundle = await readFile('out/bundle.js', 'utf8');
+          // Remove the source mapping URL
+          const nomapref = bundle.replace(/\r?\n\/\/#\s*sourceMappingURL=.+$/m, '');
+          await writeFile('out/bundle-nomapref.js', nomapref);
+          // Set the source mapping URL to a missing file - append ".none" to it
+          const missingmap = bundle.replace(/(\r?\n\/\/#\s*sourceMappingURL=.+)$/m, '$1.none');
+          await writeFile('out/bundle-missingmap.js', missingmap);
+        }
+      }]
+    }
+  },
+  {
+    input: 'src/shared.js',
+    output: {
+      file: 'out/shared.js',
+      format: 'iife',
+      name: 'shared',
+      sourcemap: 'inline',
+      sourcemapPathTransform
+    }
+  },
+];

--- a/test/rollup.config.js
+++ b/test/rollup.config.js
@@ -24,6 +24,10 @@ module.exports = [
           // Set the source mapping URL to a missing file - append ".none" to it
           const missingmap = bundle.replace(/(\r?\n\/\/#\s*sourceMappingURL=.+)$/m, '$1.none');
           await writeFile('out/bundle-missingmap.js', missingmap);
+          // Corrupt the source map content
+          const corruptedmap = bundle.replace(/(\r?\n\/\/#\s*sourceMappingURL=bundle).+$/m, '$1-corruptedmap.js.map');
+          await writeFile('out/bundle-corruptedmap.js', corruptedmap);
+          await writeFile('out/bundle-corruptedmap.js.map', '{');
         }
       }]
     }
@@ -48,6 +52,10 @@ module.exports = [
           const invalid = shared.replace(/(\r?\n\/\/#\s*sourceMappingURL=data:application\/json).+$/m,
             `$1;${encodeURIComponent(Buffer.from(map, 'base64').toString())}`);
           await writeFile('out/shared-invalid.js', invalid);
+          // Corrupt the source map content
+          const corrupted = shared.replace(/(\r?\n\/\/#\s*sourceMappingURL=data:application\/json).+$/m,
+            '$1;charset=utf-8;base64,ewo=');
+          await writeFile('out/shared-corrupted.js', corrupted);
         }
       }]
     }

--- a/test/src/shared.js
+++ b/test/src/shared.js
@@ -1,0 +1,3 @@
+export default function shared() {
+  console.log();
+}

--- a/test/src/source.js
+++ b/test/src/source.js
@@ -1,0 +1,2 @@
+import shared from './shared.js'
+shared()

--- a/test/test-source-root.js
+++ b/test/test-source-root.js
@@ -1,0 +1,27 @@
+function fetchFile(name) {
+  const url = `/base/out/${name}`;
+  return fetch(url).then(response => response.text());
+}
+
+describe('set sourceRoot', () => {
+  it('sets sourceRoot in an inline source map', async () => {
+    const content = await fetchFile('shared.js');
+    expect(content).toBe(`var shared = (function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  return shared;
+
+})();
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic2hhcmVkLmpzIiwic291cmNlcyI6WyIvdGVzdC9zaGFyZWQuanMiXSwic291cmNlc0NvbnRlbnQiOlsiZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24gc2hhcmVkKCkge1xuICBjb25zb2xlLmxvZygpO1xufVxuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7OztFQUFlLFNBQVMsTUFBTSxHQUFHO0VBQ2pDLEVBQUUsT0FBTyxDQUFDLEdBQUcsRUFBRSxDQUFDO0VBQ2hCOzs7Ozs7OzsifQ==
+`);
+  });
+
+  it('sets sourceRoot in an external source map', async () => {
+    const map = JSON.parse(await fetchFile('bundle.js.map'));
+    expect(map.sourceRoot).toBe('/sources');
+  });
+});

--- a/test/test-sources.js
+++ b/test/test-sources.js
@@ -3,7 +3,7 @@ function fetchFile(name) {
   return fetch(url).then(response => response.text());
 }
 
-describe('the preprocessor', () => {
+describe('remap source prefixes', () => {
   it('remaps sources in a base64 inline source map', async () => {
     const content = await fetchFile('shared.js');
     expect(content).toBe(`var shared = (function () {

--- a/test/test.js
+++ b/test/test.js
@@ -36,7 +36,7 @@ describe('the preprocessor', () => {
 `);
   });
 
-  it('leaves an invalid inline source map intact', async () => {
+  it('leaves an invalid inline source mapping intact', async () => {
     const code = await fetchFile('shared-invalid.js');
     expect(code).toBe(`var shared = (function () {
   'use strict';
@@ -49,6 +49,22 @@ describe('the preprocessor', () => {
 
 })();
 //# sourceMappingURL=data:application/json;%7B%22version%22%3A3%2C%22file%22%3A%22shared.js%22%2C%22sources%22%3A%5B%22%2Ftest%2Fshared.js%22%5D%2C%22sourcesContent%22%3A%5B%22export%20default%20function%20shared()%20%7B%5Cn%20%20console.log()%3B%5Cn%7D%5Cn%22%5D%2C%22names%22%3A%5B%5D%2C%22mappings%22%3A%22%3B%3B%3BEAAe%2CSAAS%2CMAAM%2CGAAG%3BEACjC%2CEAAE%2COAAO%2CCAAC%2CGAAG%2CEAAE%2CCAAC%3BEAChB%3B%3B%3B%3B%3B%3B%3B%3B%22%7D
+`);
+  });
+
+  it('leaves a corrupted inline source map content intact', async () => {
+    const code = await fetchFile('shared-corrupted.js');
+    expect(code).toBe(`var shared = (function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  return shared;
+
+})();
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,ewo=
 `);
   });
 
@@ -81,6 +97,22 @@ describe('the preprocessor', () => {
 
 })();
 //# sourceMappingURL=bundle.js.map.none
+`);
+  });
+
+  it('leaves a corrupted external source map content intact', async () => {
+    const code = await fetchFile('bundle-corruptedmap.js');
+    expect(code).toBe(`(function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  shared();
+
+})();
+//# sourceMappingURL=bundle-corruptedmap.js.map
 `);
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -50,4 +50,11 @@ describe('the preprocessor', () => {
 })();
 `);
   });
+
+  it('remaps sources in an external source map', async () => {
+    const map = JSON.parse(await fetchFile('bundle.js.map'));
+    for (const source of map.sources) {
+      expect(source).toContain('../src/');
+    }
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,38 @@ describe('the preprocessor', () => {
 `);
   });
 
+  it('remaps sources in a raw inline source map', async () => {
+    const content = await fetchFile('shared-raw.js');
+    expect(content).toBe(`var shared = (function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  return shared;
+
+})();
+//# sourceMappingURL=data:application/json,%7B%22version%22%3A3%2C%22file%22%3A%22shared.js%22%2C%22sources%22%3A%5B%22%2Ftest%2Fshared.js%22%5D%2C%22sourcesContent%22%3A%5B%22export%20default%20function%20shared()%20%7B%5Cn%20%20console.log()%3B%5Cn%7D%5Cn%22%5D%2C%22names%22%3A%5B%5D%2C%22mappings%22%3A%22%3B%3B%3BEAAe%2CSAAS%2CMAAM%2CGAAG%3BEACjC%2CEAAE%2COAAO%2CCAAC%2CGAAG%2CEAAE%2CCAAC%3BEAChB%3B%3B%3B%3B%3B%3B%3B%3B%22%7D
+`);
+  });
+
+  it('leaves an invalid inline source map intact', async () => {
+    const code = await fetchFile('shared-invalid.js');
+    expect(code).toBe(`var shared = (function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  return shared;
+
+})();
+//# sourceMappingURL=data:application/json;%7B%22version%22%3A3%2C%22file%22%3A%22shared.js%22%2C%22sources%22%3A%5B%22%2Ftest%2Fshared.js%22%5D%2C%22sourcesContent%22%3A%5B%22export%20default%20function%20shared()%20%7B%5Cn%20%20console.log()%3B%5Cn%7D%5Cn%22%5D%2C%22names%22%3A%5B%5D%2C%22mappings%22%3A%22%3B%3B%3BEAAe%2CSAAS%2CMAAM%2CGAAG%3BEACjC%2CEAAE%2COAAO%2CCAAC%2CGAAG%2CEAAE%2CCAAC%3BEAChB%3B%3B%3B%3B%3B%3B%3B%3B%22%7D
+`);
+  });
+
   it('leaves a valid external source map reference intact', async () => {
     const code = await fetchFile('bundle.js');
     expect(code).toBe(`(function () {
@@ -33,6 +65,22 @@ describe('the preprocessor', () => {
 
 })();
 //# sourceMappingURL=bundle.js.map
+`);
+  });
+
+  it('leaves an invalid external source map reference intact', async () => {
+    const code = await fetchFile('bundle-missingmap.js');
+    expect(code).toBe(`(function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  shared();
+
+})();
+//# sourceMappingURL=bundle.js.map.none
 `);
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,53 @@
+function fetchFile(name) {
+  const url = `/base/out/${name}`;
+  return fetch(url).then(response => response.text());
+}
+
+describe('the preprocessor', () => {
+  it('remaps sources in a base64 inline source map', async () => {
+    const content = await fetchFile('shared.js');
+    expect(content).toBe(`var shared = (function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  return shared;
+
+})();
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic2hhcmVkLmpzIiwic291cmNlcyI6WyIvdGVzdC9zaGFyZWQuanMiXSwic291cmNlc0NvbnRlbnQiOlsiZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24gc2hhcmVkKCkge1xuICBjb25zb2xlLmxvZygpO1xufVxuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7OztFQUFlLFNBQVMsTUFBTSxHQUFHO0VBQ2pDLEVBQUUsT0FBTyxDQUFDLEdBQUcsRUFBRSxDQUFDO0VBQ2hCOzs7Ozs7OzsifQ==
+`);
+  });
+
+  it('leaves a valid external source map reference intact', async () => {
+    const code = await fetchFile('bundle.js');
+    expect(code).toBe(`(function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  shared();
+
+})();
+//# sourceMappingURL=bundle.js.map
+`);
+  });
+
+  it('leaves the code without an external source map reference intact', async () => {
+    const code = await fetchFile('bundle-nomapref.js');
+    expect(code).toBe(`(function () {
+  'use strict';
+
+  function shared() {
+    console.log();
+  }
+
+  shared();
+
+})();
+`);
+  });
+});


### PR DESCRIPTION
If the source map contains paths like `/myproject/*` set during the build instead of `../src/*`, so that the source paths do not conflict in a large application, code coverage testing tools will not be able to find the source files on the disk to create the report. When loading the source files and source maps for the preprocessors, the source paths can be changed to point to the source file locations in the current project, which may mean back to `../src/*`, for example.

## Features

* Allow remapping or otherwise changing source paths in source maps
* Allow changing `sourceRoot` in source maps
* Allow adapting the source map files alone, if served separately by the Karma web server
* Add option `onlyWithURL` to disable the source map loading for files without `sourceMapingURL`
* Add option `strict` for a strict error handling of invalid and missing source maps

## Fixes

* Fix handling of raw (URI-encoded) source maps - trim the leading `,` before parsing the content
* Warn about a missing external source map, is the source mapping URL is invalid
* Handle malformed source map content as a warning or failure

## Chores

* Introduce unit tests for the existing functionality
